### PR TITLE
Remove duplicate WAKE_LOCK

### DIFF
--- a/Sport.Android/Providers/PushNotifications.cs
+++ b/Sport.Android/Providers/PushNotifications.cs
@@ -15,7 +15,6 @@ using System.Diagnostics;
 
 [assembly: UsesPermission(Name = "android.permission.GET_ACCOUNTS")]
 [assembly: UsesPermission(Name = "android.permission.INTERNET")]
-[assembly: UsesPermission(Name = "android.permission.WAKE_LOCK")]
 
 [assembly: Dependency(typeof(Sport.Android.PushNotifications))]
 


### PR DESCRIPTION
From Desk case #247558

> I was looking at the sample code and i was wondering why are we repating these lines in the code file
`[assembly: UsesPermission(Name = "android.permission.WAKE_LOCK")]`