### PR TITLE
Add null check in GetChallengeConflictReason

### DIFF
--- a/Sport.Mobile.Shared/Helpers/Extensions.cs
+++ b/Sport.Mobile.Shared/Helpers/Extensions.cs
@@ -111,6 +111,9 @@ namespace Sport.Mobile.Shared
 
 		public static string GetChallengeConflictReason(this Membership membership, Athlete athlete)
 		{
+			if (membership == null)
+				return null;
+
 			if(!membership.League.HasStarted)
 				return "The league hasn't started yet";
 


### PR DESCRIPTION
From [51134](https://bugzilla.xamarin.com/show_bug.cgi?id=51134) on Bugzilla, it seems like the XAML not working with the Forms previewer on one of the pages mentioned (`MembershipDetailsPage`) is due to the `membership` value being null, and adding a check seems to alleviate this issue. The other one is a bit more unclear (some sort of NRE) so I'll file an issue for it.