### PR TITLE
Update click handler signatures

### DIFF
--- a/Sport.Mobile.Shared/Pages/ChallengeDetailsPage.xaml.cs
+++ b/Sport.Mobile.Shared/Pages/ChallengeDetailsPage.xaml.cs
@@ -223,12 +223,12 @@ namespace Sport.Mobile.Shared
 			return lst;
 		}
 
-		void OnRefreshClicked()
+		void OnRefreshClicked(object sender, EventArgs e)
 		{
 			OnRefreshChallenge();
 		}
 
-		async void OnMoreClicked()
+		async void OnMoreClicked(object sender, EventArgs e)
 		{
 			var lst = GetMoreMenuOptions();
 			var action = await DisplayActionSheet("Additional actions", "Cancel", null, lst.ToArray());


### PR DESCRIPTION
Per [51727](https://bugzilla.xamarin.com/show_bug.cgi?id=51727), the XAML Previewer complains about the method signatures on the click handlers. There's a separate issue in the Initializer but I don't think it has anything to do with the code. Doesn't hurt to fix this though.